### PR TITLE
fix: update default type of id field

### DIFF
--- a/scripts/graph-compiler/schema/schema_entry_field.js
+++ b/scripts/graph-compiler/schema/schema_entry_field.js
@@ -1,5 +1,5 @@
 class SchemaEntryField {
-  constructor({ name = 'id', type = 'ID!', derived = null } = {}) {
+  constructor({ name = 'id', type = 'Bytes!', derived = null } = {}) {
     this.name    = name;
     this.type    = type;
     this.derived = derived;


### PR DESCRIPTION
- When we create the `id` field of an entity in a schema, it gets set to `ID!`.
- If the entity name is the same as the entity name in a schema - which follows the updated convention of having the type of `id` as `Bytes` a conflict error is thrown. 
- Since it's now faster to use `Bytes`, I've updated the default type of `id` field to 
1. Avoid conflict
2. Use the new best practice for speed


Same as https://github.com/Amxx/graphprotocol-utils/pull/13